### PR TITLE
Fix: BaseResponse가 Flux 데이터 타입으로 날라오는 버그를 수정했습니다.

### DIFF
--- a/src/main/kotlin/com/example/aandi_post_web_server/post/controller/PostController.kt
+++ b/src/main/kotlin/com/example/aandi_post_web_server/post/controller/PostController.kt
@@ -40,8 +40,10 @@ class PostController(
 
     @Operation(summary = "전체조회", description = "전체의 공지를 가져오는 API입니다.")
     @GetMapping
-    private suspend fun getAllPost() : Flux<BaseResponse<Post>> {
-        return postService.getAllPost()
-            .map { post -> BaseResponse(data = post) }
+    private suspend fun getAllPost() : BaseResponse<Flux<Post>> {
+        val result = postService.getAllPost()
+        return BaseResponse<Flux<Post>>(
+            data = result
+        )
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
 
   data:
     mongodb:
-      database: ${MONGO_DB_NAME}
-      port: ${MONGO_PORT}
-      uri: ${MONGO_DB_URL}
+      host: mongodb-container
+      database: aandi
+      port: 27017
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
 
   data:
     mongodb:
-      host: mongodb-container
-      database: aandi
-      port: 27017
+      database: ${MONGO_DB_NAME}
+      port: ${MONGO_PORT}
+      uri: ${MONGO_DB_URL}
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
```kotlin
private suspend fun getAllPost() : Flux<BaseResponse<Post>> {
        return postService.getAllPost()
            .map { post -> BaseResponse(data = post) }
```

기존의 코드는 Flux에 BaseResponse를 집어넣어서 배열이 날라오고 있었으나,

```kotlin
@Operation(summary = "전체조회", description = "전체의 공지를 가져오는 API입니다.")
    @GetMapping
    private suspend fun getAllPost() : BaseResponse<Flux<Post>> {
        val result = postService.getAllPost()
        return BaseResponse<Flux<Post>>(
            data = result
        )
    }
```

이젠 정상적으로 BaseResponse에 Flux가 담겨져서 반환됩니다.